### PR TITLE
Fix total MACs error

### DIFF
--- a/torchinfo/layer_info.py
+++ b/torchinfo/layer_info.py
@@ -30,6 +30,10 @@ class LayerInfo:
         self.executed = False
         self.parent_info = parent_info
         self.var_name = var_name
+        self.leaf_layer = True
+        for name, param in self.module.named_parameters():
+            if "." in name:
+                self.leaf_layer = False
 
         # Statistics
         self.trainable = True
@@ -132,19 +136,20 @@ class LayerInfo:
         Please note: Returned MACs is the number of MACs for the full tensor,
         i.e., taking the batch-dimension into account.
         """
-        for name, param in self.module.named_parameters():
-            if name == "weight":
-                # ignore C when calculating Mult-Adds in ConvNd
-                if "Conv" in self.class_name:
-                    self.macs += int(
-                        param.nelement()
-                        * prod(self.output_size[:1] + self.output_size[2:])
-                    )
-                else:
-                    self.macs += self.output_size[0] * param.nelement()
-            # RNN modules have inner weights such as weight_ih_l0
-            elif "weight" in name:
-                self.macs += prod(self.output_size[:2]) * param.nelement()
+        if self.leaf_layer:
+            for name, param in self.module.named_parameters():
+                if name == "weight":
+                    # ignore C when calculating Mult-Adds in ConvNd
+                    if "Conv" in self.class_name:
+                        self.macs += int(
+                            param.nelement()
+                            * prod(self.output_size[:1] + self.output_size[2:])
+                        )
+                    else:
+                        self.macs += self.output_size[0] * param.nelement()
+                # RNN modules have inner weights such as weight_ih_l0
+                elif "weight" in name:
+                    self.macs += prod(self.output_size[:2]) * param.nelement()
 
     def check_recursive(self, summary_list: List["LayerInfo"]) -> None:
         """

--- a/torchinfo/layer_info.py
+++ b/torchinfo/layer_info.py
@@ -80,7 +80,7 @@ class LayerInfo:
 
         elif isinstance(inputs, torch.Tensor):
             size = list(inputs.size())
-            if batch_dim is not None:
+            if batch_dim is not None and len(size) > batch_dim:
                 size[batch_dim] = 1
 
         elif isinstance(inputs, (list, tuple)):

--- a/torchinfo/layer_info.py
+++ b/torchinfo/layer_info.py
@@ -138,7 +138,7 @@ class LayerInfo:
         """
         if self.leaf_layer:
             for name, param in self.module.named_parameters():
-                if name == "weight":
+                if name == "weight" or name == "bias":
                     # ignore C when calculating Mult-Adds in ConvNd
                     if "Conv" in self.class_name:
                         self.macs += int(
@@ -148,7 +148,7 @@ class LayerInfo:
                     else:
                         self.macs += self.output_size[0] * param.nelement()
                 # RNN modules have inner weights such as weight_ih_l0
-                elif "weight" in name:
+                elif "weight" in name or "bias" in name:
                     self.macs += prod(self.output_size[:2]) * param.nelement()
 
             self.update_parent_macs(self.parent_info, self.macs)

--- a/torchinfo/layer_info.py
+++ b/torchinfo/layer_info.py
@@ -151,6 +151,16 @@ class LayerInfo:
                 elif "weight" in name:
                     self.macs += prod(self.output_size[:2]) * param.nelement()
 
+            self.update_parent_macs(self.parent_info, self.macs)
+
+    def update_parent_macs(self, parent_info: Optional["LayerInfo"], macs: int) -> None:
+        """
+        Accumulate MACs of current layer to ancestor layers.
+        """
+        parent_info.macs += macs
+        if parent_info.parent_info is not None:
+            self.update_parent_macs(parent_info.parent_info, macs)
+
     def check_recursive(self, summary_list: List["LayerInfo"]) -> None:
         """
         If the current module is already-used, mark as (recursive).

--- a/torchinfo/model_statistics.py
+++ b/torchinfo/model_statistics.py
@@ -56,11 +56,12 @@ class ModelStatistics:
         )
         if self.input_size:
             summary_str += (
-                "Total mult-adds ({}): {:0.2f}\n{}\n"
+                "Total mult-adds: {:,} ({:0.2f}{})\n{}\n"
                 "Input size (MB): {:0.2f}\n"
                 "Forward/backward pass size (MB): {:0.2f}\n"
                 "Params size (MB): {:0.2f}\n"
                 "Estimated Total Size (MB): {:0.2f}\n".format(
+                    self.total_mult_adds,
                     *self.to_readable(self.total_mult_adds),
                     divider,
                     self.to_bytes(self.total_input),
@@ -80,10 +81,10 @@ class ModelStatistics:
         return num * 4 / 1e6
 
     @staticmethod
-    def to_readable(num: int) -> Tuple[str, float]:
+    def to_readable(num: int) -> Tuple[float, str]:
         """Converts a number to millions, billions, or trillions."""
         if num >= 1e12:
-            return "T", num / 1e12
+            return num / 1e12, "T"
         if num >= 1e9:
-            return "G", num / 1e9
-        return "M", num / 1e6
+            return num / 1e9, "G"
+        return num / 1e6, "M"

--- a/torchinfo/model_statistics.py
+++ b/torchinfo/model_statistics.py
@@ -26,7 +26,8 @@ class ModelStatistics:
         self.total_input = sum(prod(sz) for sz in input_size) if input_size else 0
 
         for layer_info in summary_list:
-            self.total_mult_adds += layer_info.macs
+            if layer_info.leaf_layer:
+                self.total_mult_adds += layer_info.macs
             if layer_info.is_recursive:
                 continue
             if layer_info.depth == formatting.max_depth or (

--- a/torchinfo/torchinfo.py
+++ b/torchinfo/torchinfo.py
@@ -152,7 +152,9 @@ def summary(
     named_module = (model.__class__.__name__, model)
     # Max number of nested layers to traverse when calculating Mult-Adds. Always calculate all layers
     calculate_depth = 1e6
-    apply_hooks(named_module, model, batch_dim, calculate_depth, summary_list, idx, hooks)
+    apply_hooks(
+        named_module, model, batch_dim, calculate_depth, summary_list, idx, hooks
+    )
 
     if device is None:
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")


### PR DESCRIPTION
1. Add attribute "leaf_layer" to LayerInfo.
2. Always calculate MACs for all layers.
3. Only structure of layers is influenced by "depth".
4. Compute total MACs by sum MACs of all **leaf** layers.
5. Add **bias MACs**
5. More detailed total MACs output.

Now the MACs calculation seems more correct.