### PR TITLE
add __version__ to torchinfo

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = torchinfo
-version = 1.5.3
+version = attr: torchinfo.__version__
 description = Model summary in PyTorch, based off of the original torchsummary.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/torchinfo/__init__.py
+++ b/torchinfo/__init__.py
@@ -4,4 +4,4 @@ from .model_statistics import ModelStatistics
 from .torchinfo import summary
 
 __all__ = ("ModelStatistics", "summary", "ALL_COLUMN_SETTINGS", "ALL_ROW_SETTINGS")
-__version__ = '1.5.3'
+__version__ = "1.5.3"

--- a/torchinfo/__init__.py
+++ b/torchinfo/__init__.py
@@ -4,3 +4,4 @@ from .model_statistics import ModelStatistics
 from .torchinfo import summary
 
 __all__ = ("ModelStatistics", "summary", "ALL_COLUMN_SETTINGS", "ALL_ROW_SETTINGS")
+__version__ = '1.5.3'


### PR DESCRIPTION
Closes https://github.com/TylerYep/torchinfo/issues/88

Not quite what we discussed. Apparently since you use a setup.cfg, you can just reference the attribute directly. See https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-package-version

Thanks again for maintaining this project. I have found it useful in my work.