### PR TITLE
Add pre-commit to requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ pylint
 pytest
 pytest-cov
 pylint_strict_informational
+pre-commit


### PR DESCRIPTION
Minor addition. Since `pre-commit install` is mentioned under the contributing section, it might be good to also add it to the requirements-dev?