### PR TITLE
Add contribution of recursive calls to total_output_bytes

### DIFF
--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -776,8 +776,8 @@ class SimpleRNN(nn.Module):
 
     def forward(self, token_embedding: torch.Tensor) -> torch.Tensor:
         b_size = token_embedding.size()[0]
-        hx = torch.randn(b_size, self.hid_dim, device="cpu")
-        cx = torch.randn(b_size, self.hid_dim, device="cpu")
+        hx = torch.randn(b_size, self.hid_dim, device=token_embedding.device)
+        cx = torch.randn(b_size, self.hid_dim, device=token_embedding.device)
 
         for _ in range(self.max_length):
             hx, cx = self.lstm(token_embedding, (hx, cx))

--- a/tests/test_output/model_with_args.out
+++ b/tests/test_output/model_with_args.out
@@ -15,7 +15,7 @@ Non-trainable params: 0
 Total mult-adds (M): 173.71
 ==========================================================================================
 Input size (MB): 0.20
-Forward/backward pass size (MB): 0.40
+Forward/backward pass size (MB): 2.41
 Params size (MB): 0.15
-Estimated Total Size (MB): 0.75
+Estimated Total Size (MB): 2.76
 ==========================================================================================

--- a/tests/test_output/recursive.out
+++ b/tests/test_output/recursive.out
@@ -15,7 +15,7 @@ Non-trainable params: 0
 Total mult-adds (M): 173.71
 ==========================================================================================
 Input size (MB): 0.20
-Forward/backward pass size (MB): 0.40
+Forward/backward pass size (MB): 2.41
 Params size (MB): 0.15
-Estimated Total Size (MB): 0.75
+Estimated Total Size (MB): 2.76
 ==========================================================================================

--- a/tests/test_output/siamese_net.out
+++ b/tests/test_output/siamese_net.out
@@ -29,7 +29,7 @@ Non-trainable params: 0
 Total mult-adds (G): 1.06
 ==========================================================================================
 Input size (MB): 0.06
-Forward/backward pass size (MB): 4.53
+Forward/backward pass size (MB): 9.07
 Params size (MB): 9.01
-Estimated Total Size (MB): 13.60
+Estimated Total Size (MB): 18.14
 ==========================================================================================

--- a/torchinfo/model_statistics.py
+++ b/torchinfo/model_statistics.py
@@ -27,14 +27,14 @@ class ModelStatistics:
         for layer_info in summary_list:
             if layer_info.is_leaf_layer:
                 self.total_mult_adds += layer_info.macs
+                if layer_info.num_params > 0:
+                    # x2 for gradients
+                    self.total_output_bytes += layer_info.output_bytes * 2
                 if layer_info.is_recursive:
                     continue
                 self.total_params += layer_info.num_params
                 self.total_param_bytes += layer_info.param_bytes
                 self.trainable_params += layer_info.trainable_params
-                if layer_info.num_params > 0:
-                    # x2 for gradients
-                    self.total_output_bytes += layer_info.output_bytes * 2
             else:
                 if layer_info.is_recursive:
                     continue


### PR DESCRIPTION
I think we should count recursive calls towards total_output_bytes (hence memory for storing intermediate gradient/output values)
It seems that this is ignored (see the relevant change in formatting.py)
This problem can be seen in #144 