### PR TITLE
Automatically get device from first model parameter if `device` parameter to `summary` is `None`

### DIFF
--- a/tests/gpu_test.py
+++ b/tests/gpu_test.py
@@ -40,3 +40,24 @@ class TestGPU:
             ),
         ):
             summary(test, dtypes=[torch.float16], input_size=(10, 2), device="cuda")
+
+
+@pytest.mark.skipif(
+    not torch.cuda.device_count() >= 2, reason="Only relevant for multi-GPU"
+)
+class TestMultiGPU:
+    """multi-GPU-only tests"""
+
+    @staticmethod
+    def test_model_stays_on_device_if_gpu() -> None:
+        model = torch.nn.Linear(10, 10).to("cuda:1")
+        summary(model)
+        model_parameter = next(model.parameters())
+        assert model_parameter.device == torch.device("cuda:1")
+
+    @staticmethod
+    def test_different_model_parts_on_different_devices() -> None:
+        model = torch.nn.Sequential(
+            torch.nn.Linear(10, 10).to(1), torch.nn.Linear(10, 10).to(0)
+        )
+        summary(model)

--- a/torchinfo/torchinfo.py
+++ b/torchinfo/torchinfo.py
@@ -206,7 +206,7 @@ def summary(
         cache_forward_pass = False
 
     if device is None:
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        device = get_device(model)
 
     validate_user_params(
         input_data, input_size, columns, col_width, device, dtypes, verbose
@@ -444,6 +444,21 @@ def set_device(data: Any, device: torch.device | str) -> Any:
         action_fn=lambda data: data.to(device, non_blocking=True),
         aggregate_fn=type,
     )
+
+
+def get_device(model: nn.Module) -> torch.device | str:
+    """
+    Gets device of first parameter of model and returns it if it is on cuda,
+    otherwise returns cuda if available or cpu if not.
+    """
+    try:
+        model_parameter = next(model.parameters())
+    except StopIteration:
+        model_parameter = None
+
+    if model_parameter is not None and model_parameter.is_cuda:
+        return model_parameter.device
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
 def get_input_data_sizes(data: Any) -> Any:


### PR DESCRIPTION
[Issue #209](https://github.com/TylerYep/torchinfo/issues/209) can be manually avoided by setting the `device` parameter of `settings`. This pull-request makes it so that if `device is None`, the device is extracted from the model (by looking at its first parameter) and, if that parameter is on cuda, using it as `device` (if it isn't, or the model has no parameters, previous behavior is maintained). This way, the issue is solved.

Ran `pre-commit` and everything passed, including the new unittests for multi-GPU.

This is my first contribution to `torchinfo` and I'm not super experienced; if there are any problems with this pull-request, I'd love some feedback :)