### PR TITLE
Automatically choose ModelStatistics output unit

### DIFF
--- a/torchinfo/enums.py
+++ b/torchinfo/enums.py
@@ -47,6 +47,7 @@ class Units(str, Enum):
     __slots__ = ()
 
     AUTO = "auto"
+    KILOBYTES = "K"
     MEGABYTES = "M"
     GIGABYTES = "G"
     TERABYTES = "T"

--- a/torchinfo/formatting.py
+++ b/torchinfo/formatting.py
@@ -21,6 +21,7 @@ CONVERSION_FACTORS = {
     Units.TERABYTES: 1e12,
     Units.GIGABYTES: 1e9,
     Units.MEGABYTES: 1e6,
+    Units.KILOBYTES: 1e3,
     Units.NONE: 1,
 }
 

--- a/torchinfo/model_statistics.py
+++ b/torchinfo/model_statistics.py
@@ -75,18 +75,18 @@ class ModelStatistics:
             macs = ModelStatistics.format_output_num(
                 self.total_mult_adds, self.formatting.macs_units
             )
-            input_size = self.to_megabytes(self.total_input)
-            output_bytes = self.to_megabytes(self.total_output_bytes)
-            param_bytes = self.to_megabytes(self.total_param_bytes)
-            total_bytes = self.to_megabytes(
+            input_size = self.to_readable(self.total_input)
+            output_bytes = self.to_readable(self.total_output_bytes)
+            param_bytes = self.to_readable(self.total_param_bytes)
+            total_bytes = self.to_readable(
                 self.total_input + self.total_output_bytes + self.total_param_bytes
             )
             summary_str += (
                 f"Total mult-adds{macs}\n{divider}\n"
-                f"Input size (MB): {input_size:0.2f}\n"
-                f"Forward/backward pass size (MB): {output_bytes:0.2f}\n"
-                f"Params size (MB): {param_bytes:0.2f}\n"
-                f"Estimated Total Size (MB): {total_bytes:0.2f}\n"
+                f"Input size ({input_size[0]}B): {input_size[1]:0.2f}\n"
+                f"Forward/backward pass size ({output_bytes[0]}B): {output_bytes[1]:0.2f}\n"
+                f"Params size ({param_bytes[0]}B): {param_bytes[1]:0.2f}\n"
+                f"Estimated Total Size ({total_bytes[0]}B): {total_bytes[1]:0.2f}\n"
             )
         summary_str += divider
         return summary_str

--- a/torchinfo/model_statistics.py
+++ b/torchinfo/model_statistics.py
@@ -109,7 +109,9 @@ class ModelStatistics:
                 return Units.TERABYTES, num / 1e12
             if num >= 1e9:
                 return Units.GIGABYTES, num / 1e9
-            return Units.MEGABYTES, num / 1e6
+            if num >= 1e6:
+                return Units.MEGABYTES, num / 1e6
+            return Units.KILOBYTES, num / 1e3
         return units, num / CONVERSION_FACTORS[units]
 
     @staticmethod


### PR DESCRIPTION
Implement [issue#315](#315)
 
Automatically choose the unit for Total mult-adds, Input size, Forward/backward pass size, Params size, and Estimated Total Size       

Output example 1:
```
==========================================================================================
Layer (type:depth-idx)                   Output Shape              Param #
==========================================================================================
small_model                              [16, 10]                  --
├─Linear: 1-1                            [16, 10]                  650
==========================================================================================
Total params: 650
Trainable params: 650
Non-trainable params: 0
Total mult-adds (K): 10.40
==========================================================================================
Input size (KB): 4.17
Forward/backward pass size (KB): 1.28
Params size (KB): 2.60
Estimated Total Size (KB): 8.05
==========================================================================================
```
Example 2:
```
.
.
.
Total params: 11,689,512
Trainable params: 11,689,512
Non-trainable params: 0
Total mult-adds (G): 181.41
==========================================================================================
Input size (MB): 60.21
Forward/backward pass size (GB): 3.97
Params size (MB): 46.76
Estimated Total Size (GB): 4.08
==========================================================================================
```