### PR TITLE
Change method to get module name

### DIFF
--- a/torchinfo/layer_info.py
+++ b/torchinfo/layer_info.py
@@ -39,7 +39,7 @@ class LayerInfo:
         self.class_name = (
             str(module.original_name)
             if isinstance(module, ScriptModule)
-            else module._get_name()
+            else str(module._get_name())
         )
         # {layer name: {col_name: value_for_row}}
         self.inner_layers: dict[str, dict[ColumnSettings, Any]] = {}

--- a/torchinfo/layer_info.py
+++ b/torchinfo/layer_info.py
@@ -39,7 +39,7 @@ class LayerInfo:
         self.class_name = (
             str(module.original_name)
             if isinstance(module, ScriptModule)
-            else module.__class__.__name__
+            else module._get_name()
         )
         # {layer name: {col_name: value_for_row}}
         self.inner_layers: dict[str, dict[ColumnSettings, Any]] = {}


### PR DESCRIPTION
Right now, torchinfo is using `module.__class__.__name__` to retrieve the nn.Module name which will be shown in the summary. However, every PyTorch module exposes a method [`_get_name()`](https://github.com/pytorch/pytorch/blob/ecf3bae40a6f2f0f3b237bde1fc4b2492765ab13/torch/nn/modules/module.py#L2926), which in the default implementation simply returns `self.__class__.__name__`. However, a custom layer could overwrite this method to return a custom module name, avoiding to directly overwrite `self.__class__.__name__` which is not a good idea in general.

Demo:

```python
class CustomLayer(torch.nn.Module):
    def __init__(
        self,
    ) -> None:
        super().__init__()
        #self.__class__.__name__ = self._get_name()

    def forward(self, input: torch.Tensor) -> torch.Tensor:
        return input
    
    def _get_name(self) -> str:
        return "CustomFancyName"

img = torch.randn(1, 3, 224, 224)
model = CustomLayer()
summary(model, input_size=[img.shape], dtypes=[torch.float32], depth=2)
```

Output:

```
==========================================================================================
Layer (type:depth-idx)                   Output Shape              Param #
==========================================================================================
CustomFancyName                         [1, 3, 224, 224]          --
==========================================================================================
Total params: 0
Trainable params: 0
Non-trainable params: 0
Total mult-adds (Units.MEGABYTES): 0
==========================================================================================
Input size (MB): 0.60
Forward/backward pass size (MB): 0.00
Params size (MB): 0.00
Estimated Total Size (MB): 0.60
==========================================================================================
```