### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/TylerYep/torchinfo/security/code-scanning/2](https://github.com/TylerYep/torchinfo/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/test.yml`, just below the trigger section and before `jobs:`.  
Best minimal fix is:

- `contents: read`

This satisfies checkout and enforces least privilege by default for all jobs in this workflow. It does not change workflow logic, matrix behavior, or steps; it only constrains token scope explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
