### PR TITLE
Only cache forward pass if the flag is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ Args:
             this can make it easier to modify the formatting of your model
             summary, e.g. changing the depth or enabled column types, especially
             in Jupyter Notebooks.
+
+            To clear the cache, import the `clear_cached_forward_pass` function:
+            from torchinfo import clear_cached_forward_pass
+            clear_cached_forward_pass()
+
             WARNING: Modifying the model architecture or input data/input size when
             this feature is enabled does not invalidate the cache or re-run the
             forward pass, and can cause incorrect summaries as a result.

--- a/torchinfo/__init__.py
+++ b/torchinfo/__init__.py
@@ -1,6 +1,6 @@
 from .enums import ColumnSettings, Mode, RowSettings, Units, Verbosity
 from .model_statistics import ModelStatistics
-from .torchinfo import summary
+from .torchinfo import clear_cached_forward_pass, summary
 
 __all__ = (
     "ColumnSettings",
@@ -9,6 +9,7 @@ __all__ = (
     "RowSettings",
     "Units",
     "Verbosity",
+    "clear_cached_forward_pass",
     "summary",
 )
 __version__ = "1.8.0"

--- a/torchinfo/torchinfo.py
+++ b/torchinfo/torchinfo.py
@@ -306,7 +306,8 @@ def forward_pass(
     add_missing_container_layers(summary_list)
     set_children_layers(summary_list)
 
-    _cached_forward_pass[model_name] = summary_list
+    if cache_forward_pass:
+        _cached_forward_pass[model_name] = summary_list
     return summary_list
 
 


### PR DESCRIPTION
Saving the results of the forward pass can unintentionally save parts of the model to memory, which can be very hard to remove all references to. We should only save the forward pass if the flag is enabled, and then only reuse it on subsequent runs again if the flag is enabled.

If the flag is used, added a note on how to clear the cache in the readme.